### PR TITLE
fix(mdx): allow code fences inside MDX components

### DIFF
--- a/src/plugins/sanitize.ts
+++ b/src/plugins/sanitize.ts
@@ -40,14 +40,32 @@ export function preprocessMdxTags() {
     transform(code: string, id: string) {
       if (!id.endsWith('.mdx')) return;
 
-      // Replace unrecognized <someTag> with `"<someTag>"`
-      const processed = code.replace(/<([a-z][a-z0-9]+)>/gi, (match, tag) => {
+      // Don't process content inside code blocks
+      const codeBlockRegex = /```[\s\S]*?```/g;
+      const codeBlocks: string[] = [];
+      let codeBlockIndex = 0;
+
+      // Replace code blocks with placeholders
+      let processedCode = code.replace(codeBlockRegex, () => {
+        const placeholder = `__CODE_BLOCK_${codeBlockIndex}__`;
+        codeBlocks[codeBlockIndex] = arguments[0];
+        codeBlockIndex++;
+        return placeholder;
+      });
+
+      // Replace unrecognized <someTag> with `"<someTag>"` (but not in code blocks)
+      processedCode = processedCode.replace(/<([a-z][a-z0-9]+)>/gi, (match, tag) => {
         const known = KNOWN_COMPONENTS.includes(tag);
         return known ? match : `\`<${tag}>\``; // wrap in backticks to keep as code
       });
 
+      // Restore code blocks
+      codeBlocks.forEach((block, index) => {
+        processedCode = processedCode.replace(`__CODE_BLOCK_${index}__`, block);
+      });
+
       return {
-        code: processed,
+        code: processedCode,
         map: null,
       };
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,9 @@ export default defineConfig({
     mdx({
       providerImportSource: '@mdx-js/preact',
       remarkPlugins: [remarkGfm, remarkSafeVars],
+      format: 'mdx',
+      development: false,
+      jsxRuntime: 'automatic',
     }),
     tailwindcss(),
     llmTxtGenerator(),


### PR DESCRIPTION
Fixes #43 - Enhanced MDX configuration and preprocessing to properly handle code fences inside MDX components like Steps/Step.

Generated with [Claude Code](https://claude.ai/code)