### PR TITLE
fix: remove leading spaces from code fence blocks in MDX

### DIFF
--- a/src/plugins/sanitize.ts
+++ b/src/plugins/sanitize.ts
@@ -40,8 +40,11 @@ export function preprocessMdxTags() {
     transform(code: string, id: string) {
       if (!id.endsWith('.mdx')) return;
 
+      // Remove leading whitespace from code fence blocks
+      let processed = code.replace(/^(\s+)(```\w*)/gm, '$2');
+
       // Replace unrecognized <someTag> with `"<someTag>"`
-      const processed = code.replace(/<([a-z][a-z0-9]+)>/gi, (match, tag) => {
+      processed = processed.replace(/<([a-z][a-z0-9]+)>/gi, (match, tag) => {
         const known = KNOWN_COMPONENTS.includes(tag);
         return known ? match : `\`<${tag}>\``; // wrap in backticks to keep as code
       });


### PR DESCRIPTION
Fixes #45

This PR resolves the issue where leading spaces before code fence blocks (like ```bash, ```javascript, etc.) were causing MDX compilation issues.

## Changes
- Added regex pattern `/^(\s+)(```\w*)/gm` to strip whitespace from code fences before processing
- Applied the fix in the `preprocessMdxTags` plugin in `src/plugins/sanitize.ts`

The fix ensures that code fence blocks with leading spaces will be properly parsed by MDX, resolving the compilation issues.

Generated with [Claude Code](https://claude.ai/code)