### PR TITLE
fix(routing): render first page at root URL without redirect

### DIFF
--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -7,14 +7,17 @@ import { Link } from 'wouter-preact';
 export function Navigation() {
     const pathname = usePathname();
 
+    const effectivePath = pathname === '/' 
+        ? ALL_NAVIGATION[0]?.groups[0]?.pages[0]?.href ?? '/' 
+        : pathname;
+
     const currentTab = useMemo(() => {
-        // Find the tab containing the current pathname
         return ALL_NAVIGATION.find(tab => 
             tab.groups.some(group => 
-                group.pages.some(page => page.href === pathname)
+                group.pages.some(page => page.href === effectivePath)
             )
         );
-    }, [pathname]);
+    }, [effectivePath]);
 
     return (
         <nav className="docucod-navigation text-base lg:text-sm">
@@ -27,7 +30,7 @@ export function Navigation() {
                             <h3 className="mt-4 text-sm font-semibold text-slate-900 dark:text-white">{group.title}</h3>
                             <ul role="list" className="mt-2 space-y-2 border-l-2 border-slate-100 lg:mt-4 lg:space-y-4 lg:border-slate-200 dark:border-slate-800">
                                 {group.pages.map((page) => {
-                                    const isActive = pathname === page.href;
+                                    const isActive = effectivePath === page.href;
                                     return (
                                         <li key={page.href} className="relative">
                                             <Link to={page.href} className={classNames(

--- a/src/components/routes.tsx
+++ b/src/components/routes.tsx
@@ -47,10 +47,13 @@ export default function Routes() {
   useEffect(() => {
     setLoading(true);
     const loadRoutes = async () => {
+      // For root path, load the first navigation page
+      const targetPath = pathname === '/' ? ALL_NAVIGATION[0].groups[0].pages[0].href : pathname;
+      
       const entries = await Promise.all(
-        Object.entries(ALL_PAGES).filter(([path]) => path === pathname).map(async ([path, loader]) => {
+        Object.entries(ALL_PAGES).filter(([path]) => path === targetPath).map(async ([path, loader]) => {
           const module = await loader();
-          const routePath = pathFromFilename(path);
+          const routePath = pathname === '/' ? '/' : pathFromFilename(path);
           return {
             path: routePath,
             component: module.default,
@@ -66,7 +69,7 @@ export default function Routes() {
 
   useEffect(() => {
     const page = ALL_NAVIGATION.find((tab) => tab.groups.find((group) => group.pages.find((page) => page.href === pathname)));
-    if (!page) {
+    if (!page && pathname !== '/') {
       navigate(ALL_NAVIGATION[0].groups[0].pages[0].href);
       window.location.reload();
     }


### PR DESCRIPTION
Fixes #61

Modify routing logic to display first navigation page content at "/" without redirecting the URL. This allows users to stay on the root path while seeing the default page content.

## Changes
- Modified `src/components/routes.tsx` to handle root path specially
- Prevent redirect when pathname is "/"
- Load first navigation page content at root URL

Generated with [Claude Code](https://claude.ai/code)